### PR TITLE
docs: fix docs examples

### DIFF
--- a/website/docs/basics.md
+++ b/website/docs/basics.md
@@ -192,7 +192,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 However, with `next-api-decorators` you can write the same handler in a declarative manner:
 
 ```ts
-import { createHandler, Body, Get, HttpCode, NotFoundException, Post, Query } from 'next-api-decorators';
+import { createHandler, Body, Get, HttpCode, NotFoundException, Post, Query, ValidationPipe } from 'next-api-decorators';
 
 class User {
   // GET /api/user

--- a/website/docs/validation.md
+++ b/website/docs/validation.md
@@ -79,8 +79,8 @@ class LocationHandler {
   @Post()
   saveLocation(@Body(ValidationPipe) body: MapMarker) {
     // Do something with the data.
-    return `Location "${body.label}" saved.';
-  }
+    return `Location "${body.label}" saved.`;
+  
 }
 
 export default createHandler(LocationHandler);

--- a/website/docs/validation.md
+++ b/website/docs/validation.md
@@ -80,7 +80,7 @@ class LocationHandler {
   saveLocation(@Body(ValidationPipe) body: MapMarker) {
     // Do something with the data.
     return `Location "${body.label}" saved.`;
-  
+  }
 }
 
 export default createHandler(LocationHandler);


### PR DESCRIPTION
This PR fixes two usage examples in docs:
- Import `ValidationPipe` in **Basics**
- Template string in **Validation** 